### PR TITLE
Fix incorrect postgresql volume path

### DIFF
--- a/packages/postgres.yml
+++ b/packages/postgres.yml
@@ -3,7 +3,7 @@
 .run_options: &run_options
   p: "5432:5432"
   e: "POSTGRES_PASSWORD=mysecretpassword"
-  v: "<%= DPM::HOME %>/data/<%= package_name %>/<%= package_tag || 'default' %>:/var/lib/postgressql/data"
+  v: "<%= DPM::HOME %>/data/<%= package_name %>/<%= package_tag || 'default' %>:/var/lib/postgresql/data"
 .run_args: &run_args
   {}
 


### PR DESCRIPTION
默认postgres的储存路径为`/var/lib/postgresql/data`，
之前拼错导致`dpm stop postgres`后会丢失数据
